### PR TITLE
Feat: CDK Project setup & sign up - part 2

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -4,9 +4,9 @@ import { config } from "dotenv";
 config();
 
 import * as cdk from "aws-cdk-lib";
-import { InfrastructureStack } from "../lib/infrastructure-stack";
+import { APIDesignerBackendStack } from "../lib/APIDesignerBackendStack";
 
 const app = new cdk.App();
-new InfrastructureStack(app, "InfrastructureStack", {
+new APIDesignerBackendStack(app, "APIDesignerBackendStack", {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -12,7 +12,7 @@ export class APIDesignerBackendStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const { userPool } = new Cognito(this, "UserPool");
+    const { userPool, client } = new Cognito(this, "UserPool");
     const httpApi = new HttpApi(this, "API");
     const { table } = new DynamoDB(this, "Table");
 
@@ -24,6 +24,7 @@ export class APIDesignerBackendStack extends Stack {
       envs: {
         TABLE_NAME: table.tableName,
         COGNITO_USER_POOL_ID: userPool.userPoolId,
+        COGNITO_CLIENT_ID: client.userPoolClientId,
       },
       duration: 5,
     });

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -16,7 +16,7 @@ export class APIDesignerBackendStack extends Stack {
     const httpApi = new HttpApi(this, "API");
     const { table } = new DynamoDB(this, "Table");
 
-    // Sign up endpoint
+    // Sign up
     const { function: SignUpLambda } = new Lambda(this, "SignUpLambda", {
       name: "signUpLambda",
       description: "Lambda used to sign up an user",
@@ -29,8 +29,19 @@ export class APIDesignerBackendStack extends Stack {
     });
     table.grantWriteData(SignUpLambda);
 
+    // Verify code
+    const { function: VerifyCodeLambda } = new Lambda(this, "VerifyCodeLambda", {
+      name: "verifyCodeLambda",
+      description: "Lambda to confirm created user",
+      entry: "src/handlers/verifyCodeLambda.ts",
+      envs: {
+        COGNITO_USER_POOL_ID: userPool.userPoolId,
+      },
+    });
+
     // endpoints
-    httpApi.addRoute({ path: "/sign-up", method: "POST", lambda: SignUpLambda });
+    httpApi.addRoute({ path: "/auth/sign-up", method: "POST", lambda: SignUpLambda });
+    httpApi.addRoute({ path: "/auth/verify-code", method: "POST", lambda: VerifyCodeLambda });
 
     addAWSApplicationTag(this);
   }

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -6,7 +6,7 @@ import { Lambda } from "./constructors/Lambda";
 import { Cognito } from "./constructors/Cognito";
 import { DynamoDB } from "./constructors/DynamoDB";
 /* Utils */
-import addAWSApplicationTag from "./utils/addAWSApplicationTag";
+import addDefaultTags from "./utils/addDefaultTags";
 
 export class APIDesignerBackendStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -43,6 +43,6 @@ export class APIDesignerBackendStack extends Stack {
     httpApi.addRoute({ path: "/auth/sign-up", method: "POST", lambda: SignUpLambda });
     httpApi.addRoute({ path: "/auth/verify-code", method: "POST", lambda: VerifyCodeLambda });
 
-    addAWSApplicationTag(this);
+    addDefaultTags(this);
   }
 }

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -8,7 +8,7 @@ import { DynamoDB } from "./constructors/DynamoDB";
 /* Utils */
 import addAWSApplicationTag from "./utils/addAWSApplicationTag";
 
-export class InfrastructureStack extends Stack {
+export class APIDesignerBackendStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -23,7 +23,6 @@ export class APIDesignerBackendStack extends Stack {
       entry: "src/handlers/SignUpLambda.ts",
       envs: {
         TABLE_NAME: table.tableName,
-        COGNITO_USER_POOL_ID: userPool.userPoolId,
         COGNITO_CLIENT_ID: client.userPoolClientId,
       },
       duration: 5,

--- a/infrastructure/lib/APIDesignerBackendStack.ts
+++ b/infrastructure/lib/APIDesignerBackendStack.ts
@@ -12,7 +12,7 @@ export class APIDesignerBackendStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const { userPool, client } = new Cognito(this, "UserPool");
+    const { client } = new Cognito(this, "UserPool");
     const httpApi = new HttpApi(this, "API");
     const { table } = new DynamoDB(this, "Table");
 
@@ -35,7 +35,7 @@ export class APIDesignerBackendStack extends Stack {
       description: "Lambda to confirm created user",
       entry: "src/handlers/verifyCodeLambda.ts",
       envs: {
-        COGNITO_USER_POOL_ID: userPool.userPoolId,
+        COGNITO_CLIENT_ID: client.userPoolClientId,
       },
     });
 

--- a/infrastructure/lib/constructors/Cognito.ts
+++ b/infrastructure/lib/constructors/Cognito.ts
@@ -44,15 +44,6 @@ export class Cognito extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
-    this.client = this.userPool.addClient("UserPoolClient", {
-      authFlows: {
-        userPassword: true,
-      },
-      idTokenValidity: Duration.hours(1),
-      accessTokenValidity: Duration.hours(1),
-      refreshTokenValidity: Duration.days(30),
-    });
-
     addAWSApplicationTag(this.userPool);
     addAWSApplicationTag(this.client);
   }

--- a/infrastructure/lib/constructors/Cognito.ts
+++ b/infrastructure/lib/constructors/Cognito.ts
@@ -44,6 +44,16 @@ export class Cognito extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
+    this.client = this.userPool.addClient("UserPoolClient", {
+      authFlows: {
+        userPassword: true,
+      },
+      idTokenValidity: Duration.hours(1),
+      accessTokenValidity: Duration.hours(1),
+      refreshTokenValidity: Duration.days(30),
+    });
+
     addDefaultTags(this.userPool);
+    addDefaultTags(this.client);
   }
 }

--- a/infrastructure/lib/constructors/Cognito.ts
+++ b/infrastructure/lib/constructors/Cognito.ts
@@ -45,6 +45,5 @@ export class Cognito extends Construct {
     });
 
     addAWSApplicationTag(this.userPool);
-    addAWSApplicationTag(this.client);
   }
 }

--- a/infrastructure/lib/constructors/Cognito.ts
+++ b/infrastructure/lib/constructors/Cognito.ts
@@ -7,7 +7,7 @@ import {
   AccountRecovery,
 } from "aws-cdk-lib/aws-cognito";
 /* Utils */
-import addAWSApplicationTag from "../utils/addAWSApplicationTag";
+import addDefaultTags from "../utils/addDefaultTags";
 
 export class Cognito extends Construct {
   public readonly userPool: UserPool;
@@ -44,6 +44,6 @@ export class Cognito extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
-    addAWSApplicationTag(this.userPool);
+    addDefaultTags(this.userPool);
   }
 }

--- a/infrastructure/lib/constructors/DynamoDB.ts
+++ b/infrastructure/lib/constructors/DynamoDB.ts
@@ -2,7 +2,7 @@ import { Construct } from "constructs";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { TableV2, AttributeType, Billing } from "aws-cdk-lib/aws-dynamodb";
 /* Utils */
-import addAWSApplicationTag from "../utils/addAWSApplicationTag";
+import addDefaultTags from "../utils/addDefaultTags";
 
 export class DynamoDB extends Construct {
   public readonly table: TableV2;
@@ -17,6 +17,6 @@ export class DynamoDB extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
-    addAWSApplicationTag(this.table);
+    addDefaultTags(this.table);
   }
 }

--- a/infrastructure/lib/constructors/HttpApi.ts
+++ b/infrastructure/lib/constructors/HttpApi.ts
@@ -8,7 +8,7 @@ import {
 } from "aws-cdk-lib/aws-apigatewayv2";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 /* Utils */
-import addAWSApplicationTag from "../utils/addAWSApplicationTag";
+import addDefaultTags from "../utils/addDefaultTags";
 
 interface AddRouteProps {
   path: string;
@@ -36,7 +36,7 @@ export class HttpApi extends Construct {
       value: this.api.url as string,
     });
 
-    addAWSApplicationTag(this.api);
+    addDefaultTags(this.api);
   }
 
   addRoute(props: AddRouteProps) {

--- a/infrastructure/lib/constructors/Lambda.ts
+++ b/infrastructure/lib/constructors/Lambda.ts
@@ -22,7 +22,7 @@ export class Lambda extends Construct {
 
     const { name, description, entry, envs, duration } = props;
     this.function = new NodejsFunction(this, "Function", {
-      functionName: name,
+      functionName: `api-designer_${name}`,
       description,
       entry,
       handler: "handler",

--- a/infrastructure/lib/constructors/Lambda.ts
+++ b/infrastructure/lib/constructors/Lambda.ts
@@ -4,7 +4,7 @@ import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 /* Utils */
-import addAWSApplicationTag from "../utils/addAWSApplicationTag";
+import addDefaultTags from "../utils/addDefaultTags";
 
 interface Props {
   name: string;
@@ -32,6 +32,6 @@ export class Lambda extends Construct {
       timeout: Duration.seconds(duration || 3),
     });
 
-    addAWSApplicationTag(this.function);
+    addDefaultTags(this.function);
   }
 }

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -12,7 +12,7 @@ export class InfrastructureStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const { userPool, client } = new Cognito(this, "UserPool");
+    const { userPool } = new Cognito(this, "UserPool");
     const httpApi = new HttpApi(this, "API");
     const { table } = new DynamoDB(this, "Table");
 
@@ -24,7 +24,6 @@ export class InfrastructureStack extends Stack {
       envs: {
         TABLE_NAME: table.tableName,
         COGNITO_USER_POOL_ID: userPool.userPoolId,
-        COGNITO_CLIENT_ID: client.userPoolClientId,
       },
       duration: 5,
     });

--- a/infrastructure/lib/utils/addDefaultTags.ts
+++ b/infrastructure/lib/utils/addDefaultTags.ts
@@ -1,5 +1,6 @@
 import { Tags, Resource, Stack } from "aws-cdk-lib";
 
-export default function addAWSApplicationTag(resource: Resource | Stack) {
+export default function addDefaultTags(resource: Resource | Stack) {
   Tags.of(resource).add("awsApplication", process.env.AWS_APPLICATION_TAG as string);
+  Tags.of(resource).add("appName", "api-designer");
 }

--- a/infrastructure/src/handlers/SignUpLambda.ts
+++ b/infrastructure/src/handlers/SignUpLambda.ts
@@ -22,7 +22,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
     await createDynamoUser(userId, userEmail);
 
-    return successfulResponse(201, { data: userId });
+    return successfulResponse(201, { userId });
   } catch (error) {
     console.log(error);
     return internalServerErrorResponse();

--- a/infrastructure/src/handlers/SignUpLambda.ts
+++ b/infrastructure/src/handlers/SignUpLambda.ts
@@ -8,10 +8,11 @@ import {
   internalServerErrorResponse,
   missingParameterResponse,
 } from "../helpers/httpResponses";
+import parseBody from "../helpers/parseBody";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
-    const body = JSON.parse(event.body || "{}");
+    const body = parseBody(event.body);
     const { userEmail, userPassword } = body;
     if (!userEmail) return missingParameterResponse("userEmail");
     if (!userPassword) return missingParameterResponse("userPassword");

--- a/infrastructure/src/handlers/SignUpLambda.ts
+++ b/infrastructure/src/handlers/SignUpLambda.ts
@@ -1,14 +1,14 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 /* Services */
-import createDynamoUser from "../services/dynamoDB/createDynamoUser";
-import createCognitoUser from "../services/cognito/createCognitoUser";
+import createDynamoUser from "@services/dynamoDB/createDynamoUser";
+import createCognitoUser from "@services/cognito/createCognitoUser";
 /* helpers */
 import {
   successfulResponse,
   internalServerErrorResponse,
   missingParameterResponse,
-} from "../helpers/httpResponses";
-import parseBody from "../helpers/parseBody";
+} from "@helpers/httpResponses";
+import parseBody from "@helpers/parseBody";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {

--- a/infrastructure/src/handlers/SignUpLambda.ts
+++ b/infrastructure/src/handlers/SignUpLambda.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 /* Services */
-import createDynamoUser from "../services/createDynamoUser";
-import createCognitoUser from "../services/createCognitoUser";
+import createDynamoUser from "../services/dynamoDB/createDynamoUser";
+import createCognitoUser from "../services/cognito/createCognitoUser";
 /* helpers */
 import {
   successfulResponse,

--- a/infrastructure/src/handlers/verifyCodeLambda.ts
+++ b/infrastructure/src/handlers/verifyCodeLambda.ts
@@ -1,0 +1,24 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+/* Services */
+import verifyUserCode from "../services/cognito/verifyUserCode";
+/* helpers */
+import {
+  successfulResponse,
+  internalServerErrorResponse,
+  missingParameterResponse,
+} from "../helpers/httpResponses";
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  try {
+    const body = JSON.parse(event.body || "{}");
+    const { userEmail, verificationCode } = body;
+    if (!userEmail) return missingParameterResponse("userEmail");
+    if (!verificationCode) return missingParameterResponse("verificationCode");
+
+    await verifyUserCode(userEmail, verificationCode);
+    return successfulResponse(204, {});
+  } catch (error) {
+    console.log(error);
+    return internalServerErrorResponse();
+  }
+};

--- a/infrastructure/src/handlers/verifyCodeLambda.ts
+++ b/infrastructure/src/handlers/verifyCodeLambda.ts
@@ -1,13 +1,13 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 /* Services */
-import verifyUserCode from "../services/cognito/verifyUserCode";
+import verifyUserCode from "@services/cognito/verifyUserCode";
 /* helpers */
 import {
   successfulResponse,
   internalServerErrorResponse,
   missingParameterResponse,
-} from "../helpers/httpResponses";
-import parseBody from "../helpers/parseBody";
+} from "@helpers/httpResponses";
+import parseBody from "@helpers/parseBody";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {

--- a/infrastructure/src/handlers/verifyCodeLambda.ts
+++ b/infrastructure/src/handlers/verifyCodeLambda.ts
@@ -7,10 +7,11 @@ import {
   internalServerErrorResponse,
   missingParameterResponse,
 } from "../helpers/httpResponses";
+import parseBody from "../helpers/parseBody";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
-    const body = JSON.parse(event.body || "{}");
+    const body = parseBody(event.body);
     const { userEmail, verificationCode } = body;
     if (!userEmail) return missingParameterResponse("userEmail");
     if (!verificationCode) return missingParameterResponse("verificationCode");

--- a/infrastructure/src/helpers/parseBody.ts
+++ b/infrastructure/src/helpers/parseBody.ts
@@ -1,0 +1,9 @@
+/* 
+  decided to use any here because that's essentially what body can be
+
+*/
+export default function parseBody(body: string | null | Record<string, unknown>): any {
+  if (!body) return {};
+  if (typeof body === "string") return JSON.stringify(body);
+  return body;
+}

--- a/infrastructure/src/helpers/parseBody.ts
+++ b/infrastructure/src/helpers/parseBody.ts
@@ -4,6 +4,6 @@
 */
 export default function parseBody(body: string | null | Record<string, unknown>): any {
   if (!body) return {};
-  if (typeof body === "string") return JSON.stringify(body);
+  if (typeof body === "string") return JSON.parse(body);
   return body;
 }

--- a/infrastructure/src/services/cognito/createCognitoUser.ts
+++ b/infrastructure/src/services/cognito/createCognitoUser.ts
@@ -1,5 +1,5 @@
 import { SignUpCommand, SignUpCommandInput } from "@aws-sdk/client-cognito-identity-provider";
-import client from "../clients/cognito";
+import client from "../../clients/cognito";
 
 export default async function createCognitoUser(email: string, password: string) {
   const clientId = process.env.COGNITO_CLIENT_ID;

--- a/infrastructure/src/services/cognito/createCognitoUser.ts
+++ b/infrastructure/src/services/cognito/createCognitoUser.ts
@@ -1,5 +1,5 @@
 import { SignUpCommand, SignUpCommandInput } from "@aws-sdk/client-cognito-identity-provider";
-import client from "../../clients/cognito";
+import client from "@clients/cognito";
 
 export default async function createCognitoUser(email: string, password: string) {
   const clientId = process.env.COGNITO_CLIENT_ID;

--- a/infrastructure/src/services/cognito/verifyUserCode.ts
+++ b/infrastructure/src/services/cognito/verifyUserCode.ts
@@ -2,7 +2,7 @@ import {
   ConfirmSignUpCommand,
   ConfirmSignUpCommandInput,
 } from "@aws-sdk/client-cognito-identity-provider";
-import client from "../../clients/cognito";
+import client from "@clients/cognito";
 
 export default async function verifyUserCode(email: string, code: string) {
   const clientId = process.env.COGNITO_CLIENT_ID;

--- a/infrastructure/src/services/cognito/verifyUserCode.ts
+++ b/infrastructure/src/services/cognito/verifyUserCode.ts
@@ -9,7 +9,7 @@ export default async function verifyUserCode(email: string, code: string) {
   if (!clientId) throw new Error("Client id not found!");
 
   const signUpParams: ConfirmSignUpCommandInput = {
-    ClientId: process.env.COGNITO_POOL_CLIENT_ID,
+    ClientId: clientId,
     ConfirmationCode: code,
     Username: email,
   };

--- a/infrastructure/src/services/cognito/verifyUserCode.ts
+++ b/infrastructure/src/services/cognito/verifyUserCode.ts
@@ -1,0 +1,19 @@
+import {
+  ConfirmSignUpCommand,
+  ConfirmSignUpCommandInput,
+} from "@aws-sdk/client-cognito-identity-provider";
+import client from "../../clients/cognito";
+
+export default async function verifyUserCode(email: string, code: string) {
+  const clientId = process.env.COGNITO_CLIENT_ID;
+  if (!clientId) throw new Error("Client id not found!");
+
+  const signUpParams: ConfirmSignUpCommandInput = {
+    ClientId: process.env.COGNITO_POOL_CLIENT_ID,
+    ConfirmationCode: code,
+    Username: email,
+  };
+
+  const signUpCommand = new ConfirmSignUpCommand(signUpParams);
+  await client.send(signUpCommand);
+}

--- a/infrastructure/src/services/dynamoDB/createDynamoUser.ts
+++ b/infrastructure/src/services/dynamoDB/createDynamoUser.ts
@@ -1,7 +1,7 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 
-import client from "../clients/dynamoDB";
+import client from "../../clients/dynamoDB";
 
 export default async function createUser(userId: string, userEmail: string) {
   const tableName = process.env.TABLE_NAME;

--- a/infrastructure/src/services/dynamoDB/createDynamoUser.ts
+++ b/infrastructure/src/services/dynamoDB/createDynamoUser.ts
@@ -1,7 +1,6 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
-
-import client from "../../clients/dynamoDB";
+import client from "@clients/dynamoDB";
 
 export default async function createUser(userId: string, userEmail: string) {
   const tableName = process.env.TABLE_NAME;

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -22,7 +22,13 @@
     "strictPropertyInitialization": false,
     "typeRoots": [
       "./node_modules/@types"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["./src/services/*"],
+      "@helpers/*": ["./src/helpers/*"],
+      "@clients/*": ["./src/clients/*"],
+    },
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Description
This PR follows up on #13 and aims to implement the code verification logic while increasing project organization.
List of changes:
- Re-arranged services into folders (src/services/[cognito / dynamodb] 
- Add path aliases - for now only to `src/services`, `src/helpers` & `src/clients`
- Rename stack to APIDesignerBackendStack
- Add `api-designer_` prefix to all lambdas
- Rename `addAWSApplicationTag` to `addDefaultTags` & add `appName` tag
- Add `parseBody` helper to help me handle requests from apigw & postman
- Add `verifyCode` lambda & needed cognito service
- Update auth routes to include `/auth` prefix

## Issues #2 #3  